### PR TITLE
Username fixes and notification fixes

### DIFF
--- a/app/controllers/admin/images_controller.rb
+++ b/app/controllers/admin/images_controller.rb
@@ -13,7 +13,7 @@ class Admin::ImagesController < Admin::AdminController
   # Delete an image for violating some of the almighty rules on ImageHex.
   # Redirects back to /admin/images so you can delete some more.
   def destroy
-    @image = Image.find(params[:id]).delete
+    @image = Image.find(params[:id]).destroy
     redirect_to "/admin/images"
   end
   ##

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -24,7 +24,7 @@ class Comment < ActiveRecord::Base
   #############
   belongs_to :commentable, polymorphic: true
   belongs_to :user
-  has_many :notifications, as: :subject
+  has_many :notifications, as: :subject, dependent: :destroy
   ###############
   # VALIDATIONS #
   ###############

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -46,7 +46,7 @@ class Image < ActiveRecord::Base
   before_post_process :downcase_extension
   has_many :tag_groups, -> {includes :tags}, dependent: :delete_all
   has_many :reports, as: :reportable, dependent: :delete_all
-
+  has_many :notifications, as: :subject, dependent: :destroy
   has_many :comments, as: :commentable, dependent: :destroy
   has_many :collection_images, dependent: :destroy
 

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -8,7 +8,7 @@ class Notification < ActiveRecord::Base
   # RELATIONS #
   #############
   belongs_to :user
-  belongs_to :subject, polymorphic: true
+  belongs_to :subject, polymorphic: true, dependent: :destroy
 
   ##
   # SCOPES

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -8,7 +8,7 @@ class Notification < ActiveRecord::Base
   # RELATIONS #
   #############
   belongs_to :user
-  belongs_to :subject, polymorphic: true, dependent: :destroy
+  belongs_to :subject, polymorphic: true
 
   ##
   # SCOPES

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -61,7 +61,8 @@ class User < ActiveRecord::Base
   ###############
   validates :name, presence: true,
     uniqueness: {case_sensitive: false},
-    format: {with: /\w+/}
+    format: {with: /^\w+$/},
+    length: {in: 2..25}
   validates :page_pref, inclusion: {:in => (1..100)}
   validates_associated :user_page
   #############

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -61,7 +61,7 @@ class User < ActiveRecord::Base
   ###############
   validates :name, presence: true,
     uniqueness: {case_sensitive: false},
-    format: {with: /^\w+$/},
+    format: {with: /\A\w+\z/},
     length: {in: 2..25}
   validates :page_pref, inclusion: {:in => (1..100)}
   validates_associated :user_page

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :user do
-   name { Faker::Internet.user_name, "_"}
+   name { Faker::Internet.user_name(nil, %w(_))}
     email { Faker::Internet.email }
     password { Faker::Internet.password(8) }
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :user do
-   name { Faker::Internet.user_name}
+   name { Faker::Internet.user_name, "_"}
     email { Faker::Internet.email }
     password { Faker::Internet.password(8) }
 

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -5,6 +5,13 @@ RSpec.describe Comment, :type => :model do
     expect(FactoryGirl.build(:comment,
                              user: nil)).to_not be_valid
   end
+  it "should commit sudoku when subject is deleted" do
+    i = FactoryGirl.create(:image)
+    c = FactoryGirl.create(:comment, commentable: i)
+    expect(c.commentable).to eq(i)
+    i.destroy
+    expect(Comment.where(id: c).first).to eq(nil)
+  end
   it "should require the commentable to be set" do
     expect(FactoryGirl.build(:comment,
                              commentable: nil)).to_not be_valid

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -4,4 +4,14 @@ RSpec.describe Notification, :type => :model do
   it {should validate_presence_of(:user)}
   it {should validate_presence_of(:subject)}
   it {should validate_presence_of(:message)}
+  describe "deletion" do
+    it "dies when the subject deletes itself" do
+      i = FactoryGirl.create(:image)
+      n = FactoryGirl.create(:notification, subject: i)
+      expect(n.subject).to eq(i)
+      i.destroy
+      expect(Image.where(id: i.id).first).to eq(nil)
+      expect(Notification.where(id: n.id).first).to eq(nil)
+    end
+  end
 end


### PR DESCRIPTION
1. Usernames now limited to disallow spaces
2. Usernames now limited to between 2 and 25 characters
3. Notifications now commit suicide if their subject object is deleted
