### PR TITLE
Remove a thing

### DIFF
--- a/app/models/tag_group_change.rb
+++ b/app/models/tag_group_change.rb
@@ -1,4 +1,3 @@
-require 'pry'
 ##
 # This class tracks changes to a tag_group. 
 #


### PR DESCRIPTION
Gets rid of a stray `require 'pry'`, which breaks it in production. This version is deployed to Heroku already. 
